### PR TITLE
Catch errors to keep the script from being unloaded

### DIFF
--- a/osdb.lua
+++ b/osdb.lua
@@ -139,13 +139,25 @@ function flag_subtitle()
     end
 end
 
-mp.add_key_binding('Ctrl+r', 'osdb_report', flag_subtitle)
-mp.add_key_binding('Ctrl+f', 'osdb_find_subtitles', find_subtitles)
+function catch(callback, ...)
+    xpcall(
+        callback,
+        function(err)
+            msg.warn(debug.traceback())
+            msg.fatal(err)
+            mp.osd_message("Error: " .. err)
+        end,
+        ...
+    )
+end
+
+mp.add_key_binding('Ctrl+r', 'osdb_report', function() catch(flag_subtitle) end)
+mp.add_key_binding('Ctrl+f', 'osdb_find_subtitles', function() catch(find_subtitles) end)
 mp.register_event('file-loaded', function (event) 
                                      -- Reset the cache
                                      subtitles = {}
                                      if options.autoLoadSubtitles then 
-                                        find_subtitles()
+                                        catch(find_subtitles)
                                      end
                                  end)
 


### PR DESCRIPTION
Sometimes the server will send a 503 response which causes an error in the script.
I noticed that when this happens, mpv will simply unload the script and you can't use it again without restarting mpv.

This patch catches any errors using `xpcall` and mimics what mpv does if the error isn't catched (show stacktrace and error message in log). It also displays the error message as an OSD message so that the user knows something failed.