### PR TITLE
Deal with subtitles file download errors

### DIFF
--- a/osdb.lua
+++ b/osdb.lua
@@ -135,11 +135,12 @@ function find_subtitles()
         mp.osd_message("No subtitles found")
         return
     end
-    -- Load first subtitle
+    -- Load current subtitle
+    mp.osd_message(string.format("Downloading subtitle %d/%d…", current_subtitle, #subtitles))
     local filename = download_file(subtitles[current_subtitle].SubDownloadLink,
                                    subtitles[current_subtitle].SubFileName)
     mp.commandv('sub_add', filename)
-    mp.osd_message("Using subtitles "..current_subtitle.."/"..#subtitles)
+    mp.osd_message(string.format("Using subtitle %d/%d", current_subtitle, #subtitles))
     -- Remember which track it is
     subtitles[current_subtitle]._sid = mp.get_property('sid')
 end

--- a/osdb.lua
+++ b/osdb.lua
@@ -119,10 +119,12 @@ function find_subtitles()
         current_subtitle = 1
         rpc.logout()
     else
-        -- Move to another subtitle
-        mp.commandv('sub_remove', subtitles[current_subtitle]._sid)
-        if options.autoFlagSubtitles then
-            flag_subtitle()
+        -- Move to the next subtitle
+        if subtitles[current_subtitle]._sid ~= nil then
+            mp.commandv('sub_remove', subtitles[current_subtitle]._sid)
+            if options.autoFlagSubtitles then
+                flag_subtitle()
+            end
         end
         current_subtitle = current_subtitle + 1
         if current_subtitle > #subtitles then


### PR DESCRIPTION
Sometimes `download_file` will raise an error due to a transient server problem.

In this case, the subtitle's `_sid` field will not be set, causing a
crash at the next execution which can't be recovered from.

This fix ignores an unset `_sid` field to allow the user to continue
cycling through the subtitles list.

Also, add an OSD message when downloading subtitles since this can take some time when the server is overloaded.