### PR TITLE
Add filename search

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Subtitle languages to search for. Default is 'eng'. Can be multiple values, comm
 
 Flag subtitles automatically when switching to the next subtitle suggestion. Default is 'no'.
 
+    allowFilenameSearch=[yes|no]
+
+Use the file name in addition to the file hash when querying the subtitles database.
+This will include more results but those might not actually match the movie (depends on how the file name is formatted).
+
 You can either add those to MPV configuration file, for example:
 
     script-opts=osdb-autoLoadSubtitles=yes,osdb-numSubtitles=100

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ At the moment, this plugin has the following options:
 Optional credentials to use with OpenSubtitles API - your login and password that you use on opensubtitles.org.
 
     autoLoadSubtitles=[yes|no]
-    
+
 Automatically load subtitles when a file is loaded. Default is 'no'.
 
     numSubtitles=10
@@ -44,20 +44,20 @@ Number of matching subtitles to query from OpenSubtitles. Default is 10. Maximum
 Subtitle languages to search for. Default is 'eng'. Can be multiple values, comma-separated.
 
     autoFlagSubtitles=[yes|no]
-    
+
 Flag subtitles automatically when switching to the next subtitle suggestion. Default is 'no'.
 
 You can either add those to MPV configuration file, for example:
 
     script-opts=osdb-autoLoadSubtitles=yes,osdb-numSubtitles=100
-    
+
 Or create a separate lua-settings/osdb.conf file with following contents:
 
     autoLoadSubtitles=yes
     numSubtitles=100
     user=foo
     password=bar
-    
+
 # Usage
 
 If *autoLoadSubtitles* is enabled, subtitles will be found automatically when a file is loaded.

--- a/osdb-rpc.lua
+++ b/osdb-rpc.lua
@@ -34,14 +34,14 @@ function osdb.query(nsubtitles, hash, size, language)
     assert(hash and size and language)
     local searchQuery = {
         {
-            moviehash = hash, 
-            moviebytesize = size, 
+            moviehash = hash,
+            moviebytesize = size,
             sublanguageid = language
         }
     }
     local limit = {limit = nsubtitles}
 
-    local ok, res = rpc.call(osdb.API, 'SearchSubtitles', 
+    local ok, res = rpc.call(osdb.API, 'SearchSubtitles',
                              osdb.token, searchQuery, limit)
     osdb.check(ok, res)
     if res.data == false then
@@ -53,7 +53,7 @@ end
 function osdb.report(subdata)
     assert(osdb.token)
     assert(subdata)
-    local ok, res = rpc.call(osdb.API, 'ReportWrongMovieHash', 
+    local ok, res = rpc.call(osdb.API, 'ReportWrongMovieHash',
                              osdb.token, subdata.IDSubMovieFile)
     osdb.check(ok, res)
 end

--- a/osdb-rpc.lua
+++ b/osdb-rpc.lua
@@ -29,16 +29,30 @@ function osdb.logout()
     osdb.check(ok, res)
 end
 
-function osdb.query(nsubtitles, hash, size, language)
+function osdb.query(nsubtitles, language, hash, size, query)
     assert(osdb.token)
-    assert(hash and size and language)
-    local searchQuery = {
+    assert(language)
+
+    local searchQuery = {}
+    if hash and size then
+        table.insert(searchQuery,
         {
             moviehash = hash,
             moviebytesize = size,
             sublanguageid = language
-        }
-    }
+        })
+    end
+
+    if query then
+        table.insert(searchQuery,
+        {
+            query = query,
+            sublanguageid = language
+        })
+    end
+
+    assert(#searchQuery > 0)
+
     local limit = {limit = nsubtitles}
 
     local ok, res = rpc.call(osdb.API, 'SearchSubtitles',

--- a/osdb.lua
+++ b/osdb.lua
@@ -27,7 +27,7 @@ read_options(options, 'osdb')
 
 local TMP = '/tmp/%s'
 
--- Movie hash function for OSDB, courtesy of 
+-- Movie hash function for OSDB, courtesy of
 -- http://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes
 function movieHash(fileName)
         local fil = io.open(fileName, "rb")
@@ -168,10 +168,10 @@ end
 
 mp.add_key_binding('Ctrl+r', 'osdb_report', function() catch(flag_subtitle) end)
 mp.add_key_binding('Ctrl+f', 'osdb_find_subtitles', function() catch(find_subtitles) end)
-mp.register_event('file-loaded', function (event) 
+mp.register_event('file-loaded', function (event)
                                      -- Reset the cache
                                      subtitles = {}
-                                     if options.autoLoadSubtitles then 
+                                     if options.autoLoadSubtitles then
                                         catch(find_subtitles)
                                      end
                                  end)


### PR DESCRIPTION
When enabled (the default), the file name will also be used as a search
query along with the file hash.

Closes #8