### PR TITLE
Add optional search by filename for subtitles (enabled by default)

### DIFF
--- a/osdb-rpc.lua
+++ b/osdb-rpc.lua
@@ -29,20 +29,12 @@ function osdb.logout()
     osdb.check(ok, res)
 end
 
-function osdb.query(nsubtitles, hash, size, language)
+function osdb.query(search_query, nsubtitles)
     assert(osdb.token)
-    assert(hash and size and language)
-    local searchQuery = {
-        {
-            moviehash = hash, 
-            moviebytesize = size, 
-            sublanguageid = language
-        }
-    }
     local limit = {limit = nsubtitles}
 
     local ok, res = rpc.call(osdb.API, 'SearchSubtitles', 
-                             osdb.token, searchQuery, limit)
+                             osdb.token, search_query, limit)
     osdb.check(ok, res)
     if res.data == false then
         error('No subtitles found in OSDb')

--- a/osdb.lua
+++ b/osdb.lua
@@ -133,8 +133,8 @@ function find_subtitles()
         end
         rpc.login(options.user, options.password)
         subtitles = rpc.query(searchQuery, options.numSubtitles)
-        rpc.logout()
         current_subtitle = 1
+        rpc.logout()
     else
         -- Move to the next subtitle
         if subtitles[current_subtitle]._sid ~= nil then


### PR DESCRIPTION
Both filename search and hash search are optional now, although enabled by default. Subtitle OSD also prints the matching mode for the subtitle (moviehash for hash match, fulltext for search match).
Alternative for #9.