### PR TITLE
Show the name of the subtitle being used/downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ At the moment, this plugin has the following options:
 Optional credentials to use with OpenSubtitles API - your login and password that you use on opensubtitles.org.
 
     autoLoadSubtitles=[yes|no]
-    
+
 Automatically load subtitles when a file is loaded. Default is 'no'.
 
     numSubtitles=10
@@ -44,20 +44,20 @@ Number of matching subtitles to query from OpenSubtitles. Default is 10. Maximum
 Subtitle languages to search for. Default is 'eng'. Can be multiple values, comma-separated.
 
     autoFlagSubtitles=[yes|no]
-    
+
 Flag subtitles automatically when switching to the next subtitle suggestion. Default is 'no'.
 
 You can either add those to MPV configuration file, for example:
 
     script-opts=osdb-autoLoadSubtitles=yes,osdb-numSubtitles=100
-    
+
 Or create a separate lua-settings/osdb.conf file with following contents:
 
     autoLoadSubtitles=yes
     numSubtitles=100
     user=foo
     password=bar
-    
+
 # Usage
 
 If *autoLoadSubtitles* is enabled, subtitles will be found automatically when a file is loaded.

--- a/osdb-rpc.lua
+++ b/osdb-rpc.lua
@@ -33,7 +33,7 @@ function osdb.query(search_query, nsubtitles)
     assert(osdb.token)
     local limit = {limit = nsubtitles}
 
-    local ok, res = rpc.call(osdb.API, 'SearchSubtitles', 
+    local ok, res = rpc.call(osdb.API, 'SearchSubtitles',
                              osdb.token, search_query, limit)
     osdb.check(ok, res)
     if res.data == false then
@@ -45,7 +45,7 @@ end
 function osdb.report(subdata)
     assert(osdb.token)
     assert(subdata)
-    local ok, res = rpc.call(osdb.API, 'ReportWrongMovieHash', 
+    local ok, res = rpc.call(osdb.API, 'ReportWrongMovieHash',
                              osdb.token, subdata.IDSubMovieFile)
     osdb.check(ok, res)
 end

--- a/osdb.lua
+++ b/osdb.lua
@@ -153,13 +153,18 @@ function find_subtitles()
         return
     end
     -- Load current subtitle
-    mp.osd_message(string.format("Downloading subtitle %d/%d…", current_subtitle, #subtitles))
-    local filename = download_file(subtitles[current_subtitle].SubDownloadLink,
-                                   subtitles[current_subtitle].SubFileName)
+    local sub = subtitles[current_subtitle]
+    mp.osd_message(string.format(
+        "[%d/%d] Downloading subtitle…\n%s",
+        current_subtitle, #subtitles, sub.SubFileName
+    ))
+    local filename = download_file(sub.SubDownloadLink,
+                                   sub.SubFileName)
     mp.commandv('sub_add', filename)
-    mp.osd_message(string.format("Using subtitle %d/%d (matched by %s)", 
-                                 current_subtitle, #subtitles,
-                                 subtitles[current_subtitle].MatchedBy))
+    mp.osd_message(string.format(
+        "[%d/%d] Using subtitle (matched by %s)\n%s",
+        current_subtitle, #subtitles, sub.MatchedBy, sub.SubFileName
+    ))
     -- Remember which track it is
     subtitles[current_subtitle]._sid = mp.get_property('sid')
 end

--- a/osdb.lua
+++ b/osdb.lua
@@ -29,7 +29,7 @@ read_options(options, 'osdb')
 
 local TMP = '/tmp/%s'
 
--- Movie hash function for OSDB, courtesy of 
+-- Movie hash function for OSDB, courtesy of
 -- http://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes
 function movieHash(fileName)
         local fil = io.open(fileName, "rb")
@@ -192,10 +192,10 @@ end
 
 mp.add_key_binding('Ctrl+r', 'osdb_report', function() catch(flag_subtitle) end)
 mp.add_key_binding('Ctrl+f', 'osdb_find_subtitles', function() catch(find_subtitles) end)
-mp.register_event('file-loaded', function (event) 
+mp.register_event('file-loaded', function (event)
                                      -- Reset the cache
                                      subtitles = {}
-                                     if options.autoLoadSubtitles then 
+                                     if options.autoLoadSubtitles then
                                         catch(find_subtitles)
                                      end
                                  end)


### PR DESCRIPTION
Also move the subtitle number to the front for better readability

(I also set the file mode back to 644, assuming this change was made by mistake)