### PR TITLE
Correcting Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Alternatively, one can use distribution Lua packages (confirmed working on Ubunt
 
 # Installation
 
-Just drop *osdb.lua* and *osdb-rpc.lua* into **~/.mpv/scripts** (or **~/.config/mpv/scripts**).
+Just drop *osdb.lua* into **~/.mpv/scripts** (or **~/.config/mpv/scripts**).
 
 # Configuration
 


### PR DESCRIPTION
Previously it said to drop osdb.lua and osdb-rpc.lua in mpv's scripts folder. But now that osdb-rpc was merged into osdb.lua that instruction became obsolete.